### PR TITLE
Re-apply custom modifications after code updates

### DIFF
--- a/wp-content/plugins/ameliabooking/src/Infrastructure/Services/Payment/StripeService.php
+++ b/wp-content/plugins/ameliabooking/src/Infrastructure/Services/Payment/StripeService.php
@@ -120,8 +120,11 @@ class StripeService extends AbstractPaymentService implements PaymentServiceInte
                 $stripeData['metadata'] = $data['metaData'];
             }
 
+            // begin mods with fallback values
             if ($data['description']) {
                 $stripeData['description'] = $data['description'];
+            } else if (!empty($data['metaData']['Customer Name'])) {
+                $stripeData['description'] = 'Payment for ' . $data['metaData']['Customer Name'] . ' - ' . $data['metaData']['Customer Email'] . ' - ' . $data['metaData']['Service'] . '';
             }
 
             $customerId = $this->createCustomer($data, $additionalStripeData);
@@ -132,7 +135,10 @@ class StripeService extends AbstractPaymentService implements PaymentServiceInte
 
             if (!empty($data['customerData']) && !empty($data['customerData']['email'])) {
                 $stripeData['receipt_email'] = $data['customerData']['email'];
+            } else if (!empty($data['metaData']['Customer Email'])) {
+                $stripeData['receipt_email'] = $data['metaData']['Customer Email'];
             }
+            // end mods with fallback values
 
             $stripeData = apply_filters(
                 'amelia_before_stripe_payment',


### PR DESCRIPTION
## Summary
- Monthly maintenance run re-applied custom modifications after this cycle's plugin updates
- `header.php` and `functions.php` (Colibri theme) already had correct customizations — no change needed (theme wasn't updated this cycle)
- `StripeService.php` (Amelia, updated 9.5.1→9.6.3) had reverted to the bare vanilla block — restored the fallback description/receipt_email logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)